### PR TITLE
feat:공고 요약 및 상세 정보 데이터 매핑 수정

### DIFF
--- a/backend/api/routers/contests.py
+++ b/backend/api/routers/contests.py
@@ -26,11 +26,13 @@ def _normalize(row: dict) -> ContestSummary:
 
     title = d1.get("title") or row.get("title")
     host = d1.get("host") or d2.get("host_organization")
+    target = d1.get("target_text")
 
     return ContestSummary(
         id=row["contest_id"],
         title=title,
         host=host,
+        target = target,
         field=d2.get("main_field"),
         prize=d2.get("award_text"),
         deadline=d1.get("reception_end"),

--- a/backend/api/routers/scholarships.py
+++ b/backend/api/routers/scholarships.py
@@ -11,7 +11,7 @@ _JOIN_SELECT = (
     "scholarship_id,source_type,title,detail_url,status,"
     "customized_detail_1(title,scholarship_type,benefit_type,summary),"
     "customized_detail_2(campus_text,grade_min,grade_max,gpa_prev_semester_value,"
-    "amount_text,eligibility_text,application_method_text,related_document_url),"
+    "amount_text,selection_period_text, eligibility_text,application_method_text,related_document_url),"
     "notice_detail_1(campus_text,author,registered_at,view_count),"
     "notice_detail_2(title,campus_text,contact_phone,raw_text,attachment_file_url,image_file_url),"
     "notice_llm(notice_title,summary,amount_text,department_text,grade_text,"
@@ -36,6 +36,7 @@ def _normalize(row: dict) -> ScholarshipSummary:
     llm = llm[0] if isinstance(llm, list) else llm
 
     title = c1.get("title") or n2.get("title") or llm.get("notice_title") or row.get("title")
+    summary = c1.get("summary") or llm.get("summary")
     amount = c2.get("amount_text") or llm.get("amount_text")
     deadline = c2.get("selection_period_text") or llm.get("application_close_date")
     organization = n1.get("author")
@@ -53,6 +54,8 @@ def _normalize(row: dict) -> ScholarshipSummary:
     return ScholarshipSummary(
         id=row["scholarship_id"],
         title=title,
+        summary = summary,
+        campus = campus_text,
         organization=organization,
         category=category,
         amount=amount,
@@ -78,7 +81,6 @@ def _normalize_detail(row: dict) -> ScholarshipDetail:
 
     return ScholarshipDetail(
         **summary.model_dump(),
-        summary=c2.get("summary") or llm.get("summary"),
         eligibility=c2.get("eligibility_text"),
         application_method=c2.get("application_method_text"),
         application_url=c2.get("detail_url"),

--- a/backend/api/schemas/contest.py
+++ b/backend/api/schemas/contest.py
@@ -7,6 +7,7 @@ class ContestSummary(BaseModel):
     id: int
     title: str | None = None
     host: str | None = None
+    target: str | None = None
     host_type: str | None = None
     field: str | None = None
     prize: str | None = None

--- a/backend/api/schemas/scholarship.py
+++ b/backend/api/schemas/scholarship.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 class ScholarshipSummary(BaseModel):
     id: int
     title: str | None = None
+    summary: str | None = None
+    campus: str | None = None
     organization: str | None = None
     category: str | None = None
     amount: str | None = None

--- a/software-4-frontend/src/data/itemsApi.js
+++ b/software-4-frontend/src/data/itemsApi.js
@@ -6,14 +6,15 @@ export function normalizeScholarship(s) {
     type: 'scholarship',
     source: s.organization || '장학공지',
     title: s.title,
-    summary: s.description || `${s.organization}에서 제공하는 ${s.category} 장학금입니다.`,
+    summary: s.summary || `${s.organization}에서 제공하는 ${s.category} 장학금입니다.`,
+    campus: s.campus || '-',
     department: s.target_departments && s.target_departments.length ? s.target_departments.join(', ') : '전체 학과',
     targetGrade: s.target_grades || [1, 2, 3, 4],
     minGpa: s.eligibility && s.eligibility.includes('3.5') ? 3.5 : (s.eligibility && s.eligibility.includes('3.0') ? 3.0 : 0),
     deadline: s.deadline || s.application_end || '',
     views: s.d_day ? Math.max(0, 100 - s.d_day) : 42,
-    amount: s.amount ? `${s.amount.toLocaleString()}원` : '상세 공고 참조',
-    externalUrl: s.application_url || '#',
+    amount: s.amount ? `${s.amount.toLocaleString()}` : '상세 공고 참조',
+    externalUrl: s.detail_url || '#',
     tags: [s.category, '장학', s.organization].filter(Boolean),
     raw: s
   }
@@ -25,6 +26,7 @@ export function normalizeContest(c) {
     type: 'contest',
     source: c.host || '대회공지',
     title: c.title,
+    target: c.target,
     summary: c.description || `${c.host}에서 주최하는 ${c.field} 공모전입니다.`,
     department: '전체 학과',
     mainField: c.field || '-',
@@ -32,8 +34,8 @@ export function normalizeContest(c) {
     minGpa: 0,
     deadline: c.deadline || c.application_end || '',
     views: c.d_day ? Math.max(0, 150 - c.d_day) : 88,
-    amount: c.prize ? `최고 상금 ${c.prize.toLocaleString()}원` : '상세 공고 참조',
-    externalUrl: c.official_url || '#',
+    amount: c.prize ? `최고 상금 ${c.prize.toLocaleString()}` : '상세 공고 참조',
+    externalUrl: c.detail_url || '#',
     tags: [c.field, c.host_type, c.participation_type, ...(c.tags || [])].filter(Boolean),
     raw: c
   }

--- a/software-4-frontend/src/pages/ItemDetail.jsx
+++ b/software-4-frontend/src/pages/ItemDetail.jsx
@@ -99,14 +99,14 @@ export default function ItemDetail() {
             {item.type === 'scholarship' ? (
               <ul>
                 <li>지원 금액 / 혜택: <strong>{item.amount}</strong></li>
-                <li>대상 캠퍼스: {item.department}</li>
+                <li>대상 캠퍼스: {item.campus}</li>
                 <li>대상 학년: {item.targetGrade.length ? `${item.targetGrade.join(', ')}학년` : '-'}</li>
                 {item.minGpa > 0 && <li>최소 평점: {item.minGpa}</li>}
                 <li>마감일: <strong>{item.deadline}</strong></li>
               </ul>
             ) : (
               <ul>
-                <li>참가 대상: {item.department || '-'}</li>
+                <li>참가 대상: {item.target || '-'}</li>
                 <li>시상/혜택: {item.amount || '-'}</li>
                 <li>분야: {item.mainField || '-'}</li>
                 <li>접수 마감: {item.deadline || '-'}</li>


### PR DESCRIPTION
백엔드 응답 스키마와 프론트 정규화 로직을 맞춰서 장학금 요약, 캠퍼스, 공모전 참가 대상, 상세 링크가 제대로 표시되도록 수정